### PR TITLE
Add --external-args option forwarded to script

### DIFF
--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -759,6 +759,8 @@ def main() -> None:
     parser = ArgumentParser()
     parser.add_argument('script_path', help='Path to Vapoursynth script',
                         type=Path, nargs='?')
+    parser.add_argument('-a', '--external-args', type=str, nargs='?',
+                        help='Arguments that will be passed to scripts')
     args = parser.parse_args()
 
     if args.script_path is None:
@@ -769,6 +771,11 @@ def main() -> None:
     if not script_path.exists():
         print('Script path is invalid.')
         sys.exit(1)
+
+    # Rewrite args so external args will be forwarded correctly
+    if args.external_args:
+        external_args = args.external_args.split()
+        sys.argv[1:] = external_args
 
     os.chdir(script_path.parent)
     app = Qt.QApplication(sys.argv)

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -510,7 +510,7 @@ class MainWindow(AbstractMainWindow):
     def patch_dark_stylesheet(self, stylesheet: str) -> str:
         return stylesheet + 'QGraphicsView { border: 0px; padding: 0px; }'
 
-    def load_script(self, script_path: Path, external_args=[]) -> None:
+    def load_script(self, script_path: Path, external_args: str = '') -> None:
         from traceback import print_exc
         import shlex
 


### PR DESCRIPTION
As we discussed earlier.
It seems to work fine with just setting `sys.argv`. 
Tested with a script with `argparse`. I have no idea if it works with other libraries as well (click, etc...).

If there's something with the implementation that bothers you, please tell me and I'll make changes accordingly.