### PR TITLE
Outputs: sort outputs by their indices

### DIFF
--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -308,6 +308,7 @@ class MainWindow(AbstractMainWindow):
     FPS_REFRESH_INTERVAL      =   150  # ms
     LOG_LEVEL         = logging.DEBUG
     OPENGL_RENDERING          = False
+    ORDERED_OUTPUTS           = False
     OUTPUT_INDEX              =     0
     PLAY_BUFFER_SIZE = FrameInterval(get_usable_cpus_count())
     PNG_COMPRESSION_LEVEL     =     0  # 0 - 100

--- a/vspreview/models/outputs.py
+++ b/vspreview/models/outputs.py
@@ -26,7 +26,7 @@ class Outputs(Qt.QAbstractListModel, QYAMLObject):
 
         local_storage = local_storage if local_storage is not None else {}
 
-        if getattr(main_window(), 'ORDERED_OUTPUTS', False):
+        if main_window().ORDERED_OUTPUTS:
             outputs = {i: vs.get_outputs()[i] for i in sorted(vs.get_outputs())}
         else:
             outputs = vs.get_outputs()

--- a/vspreview/models/outputs.py
+++ b/vspreview/models/outputs.py
@@ -7,7 +7,7 @@ from   PyQt5       import Qt
 import vapoursynth as     vs
 
 from vspreview.core  import Output, QYAMLObjectSingleton, QYAMLObject
-from vspreview.utils import debug
+from vspreview.utils import debug, main_window
 
 
 # TODO: support non-YUV outputs
@@ -25,7 +25,13 @@ class Outputs(Qt.QAbstractListModel, QYAMLObject):
         self.items: List[Output] = []
 
         local_storage = local_storage if local_storage is not None else {}
-        for i, vs_output in vs.get_outputs().items():
+
+        if getattr(main_window(), 'ORDERED_OUTPUTS', False):
+            outputs = {i: vs.get_outputs()[i] for i in sorted(vs.get_outputs())}
+        else:
+            outputs = vs.get_outputs()
+
+        for i, vs_output in outputs.items():
             try:
                 output = local_storage[str(i)]
                 output.__init__(vs_output, i)  # type: ignore

--- a/vspreview/models/outputs.py
+++ b/vspreview/models/outputs.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from   collections import OrderedDict
 import logging
-from   typing  import Any, cast, Iterator, List, Mapping, Optional
+from   typing      import Any, cast, Iterator, List, Mapping, Optional
 
 from   PyQt5       import Qt
 import vapoursynth as     vs
@@ -27,7 +28,7 @@ class Outputs(Qt.QAbstractListModel, QYAMLObject):
         local_storage = local_storage if local_storage is not None else {}
 
         if main_window().ORDERED_OUTPUTS:
-            outputs = {i: vs.get_outputs()[i] for i in sorted(vs.get_outputs())}
+            outputs = OrderedDict(sorted(vs.get_outputs().items()))
         else:
             outputs = vs.get_outputs()
 


### PR DESCRIPTION
```py
clipa.set_output()
clipb.set_output(5)
clipc.set_output(2)
```
will result in the output dropdown menu be disordered: 
![image](https://user-images.githubusercontent.com/10972040/92584011-1f5a9100-f261-11ea-842d-53bcba089121.png)

This gives the option to change that (defaults to old behavior).