### PR TITLE
vspreview/main.py: fix sys.argv[0] passed to the vpy

### DIFF
--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -486,7 +486,7 @@ class MainWindow(AbstractMainWindow):
             self.external_args = shlex.split(external_args)
         try:
             argv_orig = sys.argv
-            sys.argv = [sys.argv[1]] + self.external_args
+            sys.argv = [script_path.name] + self.external_args
         except AttributeError:
             pass
 


### PR DESCRIPTION
We used to pass outside sys.argv[1], which might be '-a', as sys.argv[0] for
the vpy. Instead, we pass the base name of the script_path as sys.argv[0]. As
we chdir to the parent of the script, this represents the correct path of the
vpy.

Signed-off-by: akarin <i@akarin.info>