### PR TITLE
vspreview: make it usable with `python3 -m vspreview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ You can use the following command to install pip modules:
 
 # Usage
 
-`python run.py script.vpy` where `script.vpy` is path to VapourSynth script.
+Assume `script.vpy` is your VapourSynth script, there are two ways to run vspreview:
+ * `python run.py script.vpy`
+ * Add this directory to your *PYTHONPATH*, and `python -m vspreview script.vpy`
 
 # Note
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ You can use the following command to install pip modules:
 
 # Usage
 
-Assume `script.vpy` is your VapourSynth script, there are two ways to run vspreview:
+Assuming `script.vpy` is your VapourSynth script, there are two ways to run vspreview:
  * `python run.py script.vpy`
- * Add this directory to your *PYTHONPATH*, and `python -m vspreview script.vpy`
+ * Add this directory (repository root) to your *PYTHONPATH*, and `python -m vspreview script.vpy`
 
 # Note
 

--- a/vspreview/__main__.py
+++ b/vspreview/__main__.py
@@ -1,0 +1,2 @@
+from .main import main
+main()


### PR DESCRIPTION
By renaming main.py to __main__.py, we can directly use `python3 -m vspreview` to start it, without using `run.py`.

Of course, this rename might cause some merging issues for forks, so an alternative and minimum change is to just create a new `__main__.py` with the following content:
```
from .main import main
main()
```

Please let me know your preferences.