### PR TITLE
vspreview/core/types.py: treat VFR clips as 1fps to avoid division by zero

### DIFF
--- a/vspreview/core/types.py
+++ b/vspreview/core/types.py
@@ -850,7 +850,7 @@ class Output(YAMLObject):
         return round(seconds * self.fps)
 
     def _calculate_seconds(self, frame_num: int) -> float:
-        return frame_num / self.fps
+        return frame_num / (self.fps or 1)
 
     def to_frame(self, time: Time) -> Frame:
         return Frame(self._calculate_frame(float(time)))


### PR DESCRIPTION
Without this change, any VFR clip will crash vsp.

As VS does not have any special VFR support, time duration for VFR clips are not well defined, so using non-zero fps here should be fine. For simplicity, I've chosen 1 fps to avoid division by zero.

Signed-off-by: akarin <i@akarin.info>