### PR TITLE
Misc: fix autosave_enabled changes unexpectedly.

### DIFF
--- a/vspreview/toolbars/misc.py
+++ b/vspreview/toolbars/misc.py
@@ -71,6 +71,7 @@ class MiscToolbar(AbstractToolbar):
 
         self.autosave_checkbox = Qt.QCheckBox(self)
         self.autosave_checkbox.setText('Autosave')
+        self.autosave_checkbox.setChecked(self.main.AUTOSAVE_ENABLED)
         layout.addWidget(self.autosave_checkbox)
 
         self.keep_on_top_checkbox = Qt.QCheckBox(self)

--- a/vspreview/toolbars/misc.py
+++ b/vspreview/toolbars/misc.py
@@ -205,6 +205,7 @@ class MiscToolbar(AbstractToolbar):
             logging.warning('Storage loading: failed to parse autosave flag.')
             autosave_enabled = self.main.AUTOSAVE_ENABLED
 
+        self.autosave_enabled = autosave_enabled
         self.autosave_checkbox.setChecked(autosave_enabled)
 
         try:


### PR DESCRIPTION
If `misc: autosave_enabled` option is set to false in .yml file, then launch vspreview and press save button in the misc toolbar, the option would be set to true incorrectly, with the autosave checkbox left unchecked.

This PR fixed it by initializing checkState of the checkbox.