### PR TITLE
Pipette: use right click to drag graphics while pipette is toggled.

### DIFF
--- a/vspreview/toolbars/pipette.py
+++ b/vspreview/toolbars/pipette.py
@@ -37,6 +37,8 @@ class PipetteToolbar(AbstractToolbar):
 
         self.setup_ui()
         self.main.graphics_view.mouseMoved.connect(self.mouse_moved)
+        self.main.graphics_view.mouseRightPress.connect(self.mouse_right_press)
+        self.main.graphics_view.mouseRightRelease.connect(self.mouse_right_release)
 
         self.pos_fmt = '{},{}'
         self.src_hex_fmt = '{:2X}'
@@ -106,6 +108,20 @@ class PipetteToolbar(AbstractToolbar):
     def mouse_moved(self, event: Qt.QMouseEvent) -> None:
         if not event.buttons() & Qt.Qt.LeftButton:
             self.update_labels(event.pos())
+
+    def mouse_right_press(self, event: Qt.QMouseEvent) -> None:
+        if self.toggle_button.isChecked():
+            self.main.graphics_view.setDragMode(Qt.QGraphicsView.ScrollHandDrag)
+        left_event = Qt.QMouseEvent(
+            Qt.QEvent.MouseButtonPress, event.pos(), Qt.Qt.LeftButton, Qt.Qt.LeftButton, Qt.Qt.NoModifier)
+        self.main.graphics_view.mousePressEvent(left_event)
+
+    def mouse_right_release(self, event: Qt.QMouseEvent) -> None:
+        if self.toggle_button.isChecked():
+            self.main.graphics_view.setDragMode(Qt.QGraphicsView.NoDrag)
+        left_event = Qt.QMouseEvent(
+            Qt.QEvent.MouseButtonRelease, event.pos(), Qt.Qt.LeftButton, Qt.Qt.LeftButton, Qt.Qt.NoModifier)
+        self.main.graphics_view.mouseReleaseEvent(left_event)
 
     def update_labels(self, local_pos: Qt.QPoint) -> None:
         from math import floor, trunc

--- a/vspreview/toolbars/pipette.py
+++ b/vspreview/toolbars/pipette.py
@@ -37,8 +37,6 @@ class PipetteToolbar(AbstractToolbar):
 
         self.setup_ui()
         self.main.graphics_view.mouseMoved.connect(self.mouse_moved)
-        self.main.graphics_view.mouseRightPress.connect(self.mouse_right_press)
-        self.main.graphics_view.mouseRightRelease.connect(self.mouse_right_release)
 
         self.pos_fmt = '{},{}'
         self.src_hex_fmt = '{:2X}'
@@ -108,20 +106,6 @@ class PipetteToolbar(AbstractToolbar):
     def mouse_moved(self, event: Qt.QMouseEvent) -> None:
         if not event.buttons() & Qt.Qt.LeftButton:
             self.update_labels(event.pos())
-
-    def mouse_right_press(self, event: Qt.QMouseEvent) -> None:
-        if self.toggle_button.isChecked():
-            self.main.graphics_view.setDragMode(Qt.QGraphicsView.ScrollHandDrag)
-        left_event = Qt.QMouseEvent(
-            Qt.QEvent.MouseButtonPress, event.pos(), Qt.Qt.LeftButton, Qt.Qt.LeftButton, Qt.Qt.NoModifier)
-        self.main.graphics_view.mousePressEvent(left_event)
-
-    def mouse_right_release(self, event: Qt.QMouseEvent) -> None:
-        if self.toggle_button.isChecked():
-            self.main.graphics_view.setDragMode(Qt.QGraphicsView.NoDrag)
-        left_event = Qt.QMouseEvent(
-            Qt.QEvent.MouseButtonRelease, event.pos(), Qt.Qt.LeftButton, Qt.Qt.LeftButton, Qt.Qt.NoModifier)
-        self.main.graphics_view.mouseReleaseEvent(left_event)
 
     def update_labels(self, local_pos: Qt.QPoint) -> None:
         from math import floor, trunc

--- a/vspreview/widgets/custom/graphicsview.py
+++ b/vspreview/widgets/custom/graphicsview.py
@@ -14,8 +14,6 @@ class GraphicsView(Qt.QGraphicsView):
     )
 
     mouseMoved = Qt.pyqtSignal(Qt.QMouseEvent)
-    mouseRightPress = Qt.pyqtSignal(Qt.QMouseEvent)
-    mouseRightRelease = Qt.pyqtSignal(Qt.QMouseEvent)
     wheelScrolled = Qt.pyqtSignal(int)
 
     def __init__(self, parent: Optional[Qt.QWidget] = None) -> None:
@@ -64,14 +62,15 @@ class GraphicsView(Qt.QGraphicsView):
             self.mouseMoved.emit(event)
 
     def mousePressEvent(self, event: Qt.QMouseEvent) -> None:
+        if event.button() == Qt.Qt.LeftButton:
+            self.drag_mode = self.dragMode()
+            self.setDragMode(Qt.QGraphicsView.ScrollHandDrag)
         super().mousePressEvent(event)
-        if event.button() == Qt.Qt.RightButton:
-            self.mouseRightPress.emit(event)
 
     def mouseReleaseEvent(self, event: Qt.QMouseEvent) -> None:
         super().mouseReleaseEvent(event)
-        if event.button() == Qt.Qt.RightButton:
-            self.mouseRightRelease.emit(event)
+        if event.button() == Qt.Qt.LeftButton:
+            self.setDragMode(self.drag_mode)
 
 
 class GraphicsImageItem:

--- a/vspreview/widgets/custom/graphicsview.py
+++ b/vspreview/widgets/custom/graphicsview.py
@@ -14,6 +14,8 @@ class GraphicsView(Qt.QGraphicsView):
     )
 
     mouseMoved = Qt.pyqtSignal(Qt.QMouseEvent)
+    mouseRightPress = Qt.pyqtSignal(Qt.QMouseEvent)
+    mouseRightRelease = Qt.pyqtSignal(Qt.QMouseEvent)
     wheelScrolled = Qt.pyqtSignal(int)
 
     def __init__(self, parent: Optional[Qt.QWidget] = None) -> None:
@@ -60,6 +62,16 @@ class GraphicsView(Qt.QGraphicsView):
         super().mouseMoveEvent(event)
         if self.hasMouseTracking():
             self.mouseMoved.emit(event)
+
+    def mousePressEvent(self, event: Qt.QMouseEvent) -> None:
+        super().mousePressEvent(event)
+        if event.button() == Qt.Qt.RightButton:
+            self.mouseRightPress.emit(event)
+
+    def mouseReleaseEvent(self, event: Qt.QMouseEvent) -> None:
+        super().mouseReleaseEvent(event)
+        if event.button() == Qt.Qt.RightButton:
+            self.mouseRightRelease.emit(event)
 
 
 class GraphicsImageItem:


### PR DESCRIPTION
Now one cannot drag a graphic when pipette toolbar is toggled, and can only use the scroll wheel to move around, which is not precise. 

Using right-click to drag graphics helps to solve the problem.