### PR TITLE
Toolbars: save toolbar layout for convenience. 

### DIFF
--- a/vspreview/core/abstracts.py
+++ b/vspreview/core/abstracts.py
@@ -128,10 +128,22 @@ class AbstractToolbar(Qt.QWidget, QABC):
             self.main.timeline.full_repaint()
 
     def __getstate__(self) -> Mapping[str, Any]:
-        return {}
+        return {
+            'toggle': self.toggle_button.isChecked()
+        }
 
     def __setstate__(self, state: Mapping[str, Any]) -> None:
-        pass
+        try:
+            toggle = state['toggle']
+            if not isinstance(toggle, bool):
+                raise TypeError
+        except (KeyError, TypeError):
+            logging.warning(
+                'Storage loading: Toolbar: failed to parse toggle')
+            toggle = self.main.TOGGLE_TOOLEBAR
+
+        if toggle:
+            self.toggle_button.click()
 
 
 class AbstractToolbars(AbstractYAMLObjectSingleton):

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -110,8 +110,8 @@ class MainToolbar(AbstractToolbar):
         self.setup_ui()
 
         self.outputs = Outputs()
-
         self.outputs_combobox.setModel(self.outputs)
+
         self.zoom_levels = ZoomLevels([
             0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 4.0, 8.0, 16.0
         ])
@@ -221,7 +221,8 @@ class MainToolbar(AbstractToolbar):
     def __getstate__(self) -> Mapping[str, Any]:
         return {
             'current_output_index': self.outputs_combobox.currentIndex(),
-            'outputs'             : self.outputs
+            'outputs'             : self.outputs,
+            'sync_outputs'        : self.sync_outputs_checkbox.isChecked()
         }
 
     def __setstate__(self, state: Mapping[str, Any]) -> None:
@@ -245,6 +246,16 @@ class MainToolbar(AbstractToolbar):
             logging.warning(
                 'Storage loading: Main toolbar: stored output index is not valid.')
             self.main.switch_output(self.main.OUTPUT_INDEX)
+
+        try:
+            sync_outputs = state['sync_outputs']
+            if not isinstance(sync_outputs, bool):
+                raise TypeError
+            if sync_outputs:
+                self.sync_outputs_checkbox.click()
+        except (KeyError, TypeError):
+            logging.warning(
+                'Storage loading: Main toolbar: failed to parse sync outputs.')
 
 
 class Toolbars(AbstractToolbars):

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -330,6 +330,7 @@ class MainWindow(AbstractMainWindow):
     # it's allowed to stretch target interval betweewn notches by N% at most
     TIMELINE_LABEL_NOTCHES_MARGIN = 20  # %
     TIMELINE_MODE             = 'frame'
+    TOGGLE_TOOLEBAR           = False
     VSP_DIR_NAME              = '.vspreview'
     # used for formats with subsampling
     VS_OUTPUT_RESIZER         = Output.Resizer.Bicubic

--- a/vspreview/toolbars/misc.py
+++ b/vspreview/toolbars/misc.py
@@ -194,6 +194,7 @@ class MiscToolbar(AbstractToolbar):
             'save_file_name_template': self.save_template_lineedit.text(),
             'show_debug'             : self.show_debug_checkbox.isChecked()
         })
+        state.update(super().__getstate__())
         return state
 
     def __setstate__(self, state: Mapping[str, Any]) -> None:
@@ -225,3 +226,5 @@ class MiscToolbar(AbstractToolbar):
             show_debug = self.main.DEBUG_TOOLBAR
 
         self.show_debug_checkbox.setChecked(show_debug)
+
+        super().__setstate__(state)

--- a/vspreview/toolbars/playback.py
+++ b/vspreview/toolbars/playback.py
@@ -371,9 +371,11 @@ class PlaybackToolbar(AbstractToolbar):
                             / (elapsed_total / len(self.fps_history)))
 
     def __getstate__(self) -> Mapping[str, Any]:
-        return {
+        state = {
             'seek_interval_frame': self.seek_frame_control.value()
         }
+        state.update(super().__getstate__())
+        return state
 
     def __setstate__(self, state: Mapping[str, Any]) -> None:
         try:
@@ -384,3 +386,5 @@ class PlaybackToolbar(AbstractToolbar):
         except (KeyError, TypeError):
             logging.warning(
                 'Storage loading: PlaybackToolbar: failed to parse seek_interval_frame')
+
+        super().__setstate__(state)

--- a/vspreview/toolbars/scening.py
+++ b/vspreview/toolbars/scening.py
@@ -1165,7 +1165,7 @@ class SceningToolbar(AbstractToolbar):
                                   .format(first_frame_text, second_frame_text))
 
     def __getstate__(self) -> Mapping[str, Any]:
-        return {
+        state = {
             'current_list_index': self.current_list_index,
             'first_frame' : self.first_frame,
             'second_frame': self.second_frame,
@@ -1173,6 +1173,8 @@ class SceningToolbar(AbstractToolbar):
             'lists'       : self.lists,
             'scening_export_template': self.export_template_lineedit.text(),
         }
+        state.update(super().__getstate__())
+        return state
 
     def __setstate__(self, state: Mapping[str, Any]) -> None:
         try:
@@ -1226,3 +1228,5 @@ class SceningToolbar(AbstractToolbar):
         except (KeyError, TypeError):
             logging.warning(
                 'Storage loading: Scening: failed to parse export template.')
+
+        super().__setstate__(state)


### PR DESCRIPTION
I added some options to .yml file so that one can preserve the toolbar layout when he closes the window. This might help someone like me who wants pipette and misc toolbars always toggled.