### PR TITLE
Scening: Always show marks in the timeline

### DIFF
--- a/vspreview/core/abstracts.py
+++ b/vspreview/core/abstracts.py
@@ -140,7 +140,7 @@ class AbstractToolbar(Qt.QWidget, QABC):
         except (KeyError, TypeError):
             logging.warning(
                 'Storage loading: Toolbar: failed to parse toggle')
-            toggle = self.main.TOGGLE_TOOLEBAR
+            toggle = self.main.TOGGLE_TOOLBAR
 
         if toggle:
             self.toggle_button.click()

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -330,7 +330,7 @@ class MainWindow(AbstractMainWindow):
     # it's allowed to stretch target interval betweewn notches by N% at most
     TIMELINE_LABEL_NOTCHES_MARGIN = 20  # %
     TIMELINE_MODE             = 'frame'
-    TOGGLE_TOOLEBAR           = False
+    TOGGLE_TOOLBAR           = False
     VSP_DIR_NAME              = '.vspreview'
     # used for formats with subsampling
     VS_OUTPUT_RESIZER         = Output.Resizer.Bicubic

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -305,9 +305,9 @@ class Toolbars(AbstractToolbars):
 
 class MainWindow(AbstractMainWindow):
     # those are defaults that can be overriden at runtime or used as fallbacks
+    ALWAYS_SHOW_SCENE_MARKS   = False
     AUTOSAVE_ENABLED          =  True
     AUTOSAVE_INTERVAL         =    60 * 1000  # s
-    ALWAYS_SHOW_SCENE_MARKS   = False
     BASE_PPI                  =    96  # PPI
     BENCHMARK_CLEAR_CACHE     = False
     BENCHMARK_REFRESH_INTERVAL =  150  # ms

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -307,6 +307,7 @@ class MainWindow(AbstractMainWindow):
     # those are defaults that can be overriden at runtime or used as fallbacks
     AUTOSAVE_ENABLED          =  True
     AUTOSAVE_INTERVAL         =    60 * 1000  # s
+    ALWAYS_SHOW_SCENE_MARKS   = False
     BASE_PPI                  =    96  # PPI
     BENCHMARK_CLEAR_CACHE     = False
     BENCHMARK_REFRESH_INTERVAL =  150  # ms

--- a/vspreview/toolbars/scening.py
+++ b/vspreview/toolbars/scening.py
@@ -1243,7 +1243,8 @@ class SceningToolbar(AbstractToolbar):
             if not isinstance(always_show_scene_marks, bool):
                 raise TypeError
         except(KeyError, TypeError):
-            logging.warning('Storage loading: Scening: failed to parse export template.')
+            logging.warning(
+                'Storage loading: Scening: failed to parse always show scene marks.')
             always_show_scene_marks = self.main.ALWAYS_SHOW_SCENE_MARKS
 
         self.always_show_scene_marks_checkbox.setChecked(always_show_scene_marks)


### PR DESCRIPTION
I added a feature to show scene marks even though the scening toolbar is not toggled. These marks will just work as bookmarks in vsedit.

If you don't like it, you can leave the new checkbox in the scening toolbar unchecked. 