### PR TITLE
Clear all cached outputs when reloading script

### DIFF
--- a/vspreview/core/types.py
+++ b/vspreview/core/types.py
@@ -684,6 +684,13 @@ class Output(YAMLObject):
         'main', 'checkerboard',
     )
 
+    def clear(self):
+        self.source_vs_output = None
+        self.source_vs_alpha  = None
+        self.vs_alpha = None
+        self.vs_output = None
+        self.format    = None
+        self.props     = None
     def __init__(self, vs_output: Union[vs.VideoNode, vs.AlphaOutputTuple], index: int) -> None:
         from vspreview.models  import SceningLists
         from vspreview.utils   import main_window

--- a/vspreview/main.py
+++ b/vspreview/main.py
@@ -362,6 +362,9 @@ class MainWindow(AbstractMainWindow):
         'script_exec_failed'
     ]
 
+    # emit when about to reload a script: clear all existing references to existing clips.
+    reload_signal = Qt.pyqtSignal()
+
     def __init__(self) -> None:
         from qdarkstyle import load_stylesheet_pyqt5
 
@@ -577,7 +580,10 @@ class MainWindow(AbstractMainWindow):
     def reload_script(self) -> None:
         if self.toolbars.misc.autosave_enabled and not self.script_exec_failed:
             self.toolbars.misc.save()
+
+        self.reload_signal.emit()
         vs.clear_outputs()
+
         self.graphics_scene.clear()
         self.load_script(self.script_path)
 

--- a/vspreview/models/outputs.py
+++ b/vspreview/models/outputs.py
@@ -32,6 +32,8 @@ class Outputs(Qt.QAbstractListModel, QYAMLObject):
         else:
             outputs = vs.get_outputs()
 
+        main_window().reload_signal.connect(self.clear_outputs)
+
         for i, vs_output in outputs.items():
             try:
                 output = local_storage[str(i)]
@@ -40,6 +42,10 @@ class Outputs(Qt.QAbstractListModel, QYAMLObject):
                 output = Output(vs_output, i)
 
             self.items.append(output)
+
+    def clear_outputs(self):
+        for o in self.items:
+            o.clear()
 
     def __getitem__(self, i: int) -> Output:
         return self.items[i]

--- a/vspreview/toolbars/pipette.py
+++ b/vspreview/toolbars/pipette.py
@@ -48,7 +48,12 @@ class PipetteToolbar(AbstractToolbar):
         self.outputs: Dict[Output, vs.VideoNode] = {}
         self.tracking = False
 
+        main.reload_signal.connect(self.clear_outputs)
+
         set_qobject_names(self)
+
+    def clear_outputs(self):
+        self.outputs.clear()
 
     def setup_ui(self) -> None:
         layout = Qt.QHBoxLayout(self)


### PR DESCRIPTION
It should fix the memory leak when reloading script.

Fixes #15.

Signed-off-by: akarin <i@akarin.info>